### PR TITLE
feat: #55 사용자, 알림 서비스에 Redis, Kafka 추가

### DIFF
--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -29,6 +29,8 @@ ext {
 
 dependencies {
     implementation project(":common")
+    implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'software.amazon.awssdk:s3:2.27.3'
     implementation 'io.awspring.cloud:spring-cloud-aws-starter:3.1.1'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/auth/docker-compose.yml
+++ b/auth/docker-compose.yml
@@ -1,0 +1,74 @@
+version: '3.8'
+
+services:
+  controller:
+    image: ngrinder/controller
+    restart: always
+    ports:
+      - "9000:80"
+      - "16001:16001"
+      - "12000-12009:12000-12009"
+    volumes:
+      - /tmp/ngrinder-controller:/opt/ngrinder-controller
+
+  agent:
+    image: ngrinder/agent
+    restart: always
+    links:
+      - controller
+
+  redis-stack:
+    image: redis/redis-stack
+    container_name: redis-stack-compose
+    restart: always
+    environment:
+      REDIS_ARGS: "--requirepass systempass"
+    ports:
+      - "6379:6379"
+      - "8001:8001"
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    platform: linux/amd64
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+    networks:
+      - kafka-net
+
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    platform: linux/amd64
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_ADVERTISED_LISTENERS: INSIDE://kafka:29092,OUTSIDE://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+      KAFKA_LISTENERS: INSIDE://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - kafka-net
+
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    platform: linux/amd64
+    ports:
+      - "8080:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092
+      KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
+      KAFKA_CLUSTERS_0_READONLY: "false"
+    networks:
+      - kafka-net
+
+networks:
+  kafka-net:

--- a/auth/src/main/java/com/tweaty/auth/application/dto/NotificationRequestDto.java
+++ b/auth/src/main/java/com/tweaty/auth/application/dto/NotificationRequestDto.java
@@ -9,17 +9,17 @@ import domain.TargetType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class NotificationRequestDto {
 
 	private UUID receiverId;
 	private TargetType targetType; //RESERVATION, WAITING, SIGNUP
-	// private UUID targetId;
 	private Set<NotiChannel> notiChannel; //WEB, EMAIL
 	private NotiType notiType; //CREATED,UPDATED, CANCELLED, REMINDER, SIGNUP
-	// private NotiStatus notiStatus; //PENDING, SENT, FAILED
 
 }

--- a/auth/src/main/java/com/tweaty/auth/application/dto/TokenReissueRequestDto.java
+++ b/auth/src/main/java/com/tweaty/auth/application/dto/TokenReissueRequestDto.java
@@ -1,0 +1,8 @@
+package com.tweaty.auth.application.dto;
+
+import lombok.Getter;
+
+@Getter
+public class TokenReissueRequestDto {
+	private String refreshToken;
+}

--- a/auth/src/main/java/com/tweaty/auth/domain/model/RefreshToken.java
+++ b/auth/src/main/java/com/tweaty/auth/domain/model/RefreshToken.java
@@ -1,0 +1,36 @@
+package com.tweaty.auth.domain.model;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@RedisHash(value = "refreshToken", timeToLive = 60 * 60 * 24 * 14)
+public class RefreshToken implements Serializable {
+
+	@Id
+	private UUID id;
+
+	private String username;
+
+	@Indexed
+	private String accessToken;
+
+	private String refreshToken;
+
+	public void updateAccessToken(String accessToken) {
+		this.accessToken = accessToken;
+	}
+
+	public void updateRefreshToken(String refreshToken) {
+		this.refreshToken = refreshToken;
+	}
+
+}

--- a/auth/src/main/java/com/tweaty/auth/infrastructure/configuration/KafkaProducerConfig.java
+++ b/auth/src/main/java/com/tweaty/auth/infrastructure/configuration/KafkaProducerConfig.java
@@ -1,0 +1,31 @@
+package com.tweaty.auth.infrastructure.configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@Configuration
+public class KafkaProducerConfig {
+
+	@Bean
+	public ProducerFactory<String, Object> producerFactory() {
+		Map<String, Object> config = new HashMap<>();
+		config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+		config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+		config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+		return new DefaultKafkaProducerFactory<>(config);
+	}
+
+	@Bean
+	public KafkaTemplate<String, Object> kafkaTemplate() {
+		return new KafkaTemplate<>(producerFactory());
+	}
+}

--- a/auth/src/main/java/com/tweaty/auth/infrastructure/security/AuthTokenProvider.java
+++ b/auth/src/main/java/com/tweaty/auth/infrastructure/security/AuthTokenProvider.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Component;
 import com.tweaty.auth.application.dto.UserDto;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -23,11 +25,11 @@ public class AuthTokenProvider {
 	@Value("${jwt.secret}")
 	private String secretKey;
 	private final long accessTokenValidTime = 60 * 60 * 1000L; //1시간
+	private final long refreshTokenValidTime = 60L * 60 * 24 * 14 * 1000; // 14일
 
 	public String createAccessToken(UserDto user) {
 
 		SecretKey key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
-
 		Date now = new Date();
 
 		return Jwts.builder()
@@ -40,11 +42,48 @@ public class AuthTokenProvider {
 			.compact();
 	}
 
+	public String createRefreshToken(UserDto user) {
+
+		SecretKey key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+		Date now = new Date();
+
+		return Jwts.builder()
+			.claim("id", user.getId())
+			.setSubject(user.getUsername())
+			.setIssuedAt(now)
+			.setExpiration(new Date(now.getTime() + refreshTokenValidTime))
+			.signWith(key, SignatureAlgorithm.HS256)
+			.compact();
+	}
+
 	public Claims parseToken(String token) {
 
 		SecretKey key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
 
 		return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+	}
+
+	public long getExpiration(String token) {
+
+		Claims claims = parseToken(token);
+		Date expiration = claims.getExpiration();
+
+		return (expiration.getTime() - System.currentTimeMillis()) / 1000;
+
+	}
+
+	public boolean validateToken(String token) {
+		try {
+			SecretKey key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+			Jws<Claims> claimsJws = Jwts.parserBuilder()
+				.setSigningKey(key)
+				.build()
+				.parseClaimsJws(token);
+
+			return !claimsJws.getBody().getExpiration().before(new Date());
+		} catch (JwtException | IllegalArgumentException e) {
+			return false;
+		}
 	}
 
 }

--- a/auth/src/main/java/com/tweaty/auth/presentation/controller/AuthController.java
+++ b/auth/src/main/java/com/tweaty/auth/presentation/controller/AuthController.java
@@ -20,6 +20,7 @@ import com.tweaty.auth.application.dto.LoginResponseDto;
 import com.tweaty.auth.application.dto.OwnerResponseDto;
 import com.tweaty.auth.application.dto.OwnerSignUpRequestDto;
 import com.tweaty.auth.application.dto.PasswordUpdateRequestDto;
+import com.tweaty.auth.application.dto.TokenReissueRequestDto;
 import com.tweaty.auth.application.dto.UserResponseDto;
 import com.tweaty.auth.application.dto.UserSignUpRequestDto;
 import com.tweaty.auth.application.service.AuthService;
@@ -95,6 +96,32 @@ public class AuthController {
 		authService.updatePassword(username, requestDto);
 
 		return SuccessResponse.successMessageOnly("비밀번호 수정 성공");
+	}
+
+	// 토큰 재발급
+	@PostMapping("/reissue")
+	public ResponseEntity<ApiResponse<LoginResponseDto>> reissueToken(
+		@RequestHeader("Authorization") String authHeader,
+		@RequestBody TokenReissueRequestDto requestDto
+	) {
+
+		String refreshToken = requestDto.getRefreshToken();
+		LoginResponseDto responseDto = authService.reissueToken(authHeader, refreshToken);
+
+		return SuccessResponse.successWith(200, "토큰 재발급 성공", responseDto);
+
+	}
+
+	//로그아웃
+	@PostMapping("/logout")
+	public ResponseEntity<ApiResponse<Map<String, Object>>> logout(
+		@RequestHeader("Authorization") String authHeader
+	) {
+
+		authService.logout(authHeader);
+
+		return SuccessResponse.successMessageOnly("로그아웃 성공");
+
 	}
 
 }

--- a/auth/src/main/resources/application.yml
+++ b/auth/src/main/resources/application.yml
@@ -15,6 +15,18 @@ spring:
         static: ap-northeast-2
       s3:
         bucket: tweaty-bucket
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      username: ${REDIS_USERNAME}
+      password: ${REDIS_PASSWORD}
+
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
 
 server:
   port: 19092

--- a/gateway/build.gradle
+++ b/gateway/build.gradle
@@ -29,6 +29,7 @@ ext {
 
 dependencies {
     //   implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/gateway/src/main/resources/application-local.yml
+++ b/gateway/src/main/resources/application-local.yml
@@ -10,3 +10,11 @@ eureka:
 
 jwt:
   secret: ${JWT_SECRET}
+
+spring:
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      username: ${REDIS_USERNAME}
+      password: ${REDIS_PASSWORD}

--- a/notification/build.gradle
+++ b/notification/build.gradle
@@ -29,6 +29,9 @@ ext {
 
 dependencies {
     implementation project(":common")
+//    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
+//    implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'org.springframework.kafka:spring-kafka'
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/notification/src/main/java/com/tweaty/notification/application/service/NotificationKafkaConsumer.java
+++ b/notification/src/main/java/com/tweaty/notification/application/service/NotificationKafkaConsumer.java
@@ -1,0 +1,26 @@
+package com.tweaty.notification.application.service;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import com.tweaty.notification.application.dto.NotificationRequestDto;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationKafkaConsumer {
+
+	private final NotificationService notificationService;
+
+	@KafkaListener(topics = "notification-topic", groupId = "notification-service-group")
+	public void consumeSignupNotification(NotificationRequestDto requestDto) {
+
+		log.info("Received signup notification: {}", requestDto);
+		notificationService.createSignupNotification(requestDto);
+
+	}
+
+}

--- a/notification/src/main/java/com/tweaty/notification/application/service/NotificationService.java
+++ b/notification/src/main/java/com/tweaty/notification/application/service/NotificationService.java
@@ -39,7 +39,6 @@ public class NotificationService {
 	private final EmailNotificationSender emailNotificationSender;
 	private final UserServiceClient userServiceClient;
 
-
 	public void createSignupNotification(NotificationRequestDto requestDto) {
 
 		for(NotiChannel notiChannel : requestDto.getNotiChannel()) {

--- a/notification/src/main/java/com/tweaty/notification/infrastructure/configuration/KafkaConsumerConfig.java
+++ b/notification/src/main/java/com/tweaty/notification/infrastructure/configuration/KafkaConsumerConfig.java
@@ -1,0 +1,47 @@
+package com.tweaty.notification.infrastructure.configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+@EnableKafka
+@Configuration
+public class KafkaConsumerConfig {
+
+	@Bean
+	public ConsumerFactory<String, Object> consumerFactory() {
+
+		Map<String, Object> configProps = new HashMap<>();
+		configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+		configProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+		configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+		configProps.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer.class);
+		configProps.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class);
+		configProps.put(JsonDeserializer.TYPE_MAPPINGS,
+			"com.tweaty.auth.application.dto.NotificationRequestDto:com.tweaty.notification.application.dto.NotificationRequestDto," +
+				"com.tweaty.user.application.dto.NotificationRequestDto:com.tweaty.notification.application.dto.NotificationRequestDto");
+		configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+
+		return new DefaultKafkaConsumerFactory<>(configProps);
+
+	}
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
+		ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+		factory.setConsumerFactory(consumerFactory());
+		return factory;
+	}
+
+}

--- a/notification/src/main/java/com/tweaty/notification/infrastructure/repository/JpaNotificationRepository.java
+++ b/notification/src/main/java/com/tweaty/notification/infrastructure/repository/JpaNotificationRepository.java
@@ -19,10 +19,10 @@ public interface JpaNotificationRepository extends JpaRepository<Notification, U
 	Page<Notification> findByReceiverIdAndNotiChannelAndNotiStatus(UUID receiverId, NotiChannel notiChannel, NotiStatus notiStatus, Pageable pageable);
 
 	@Modifying(clearAutomatically = true)
-	@Query("UPDATE Notification n SET n.isRead = true WHERE n.receiverId = :id AND n.isRead = false")
+	@Query("UPDATE Notification n SET n.isRead = true WHERE n.receiverId = :id AND n.isRead = false AND n.notiChannel = 'WEB'")
 	int markAllAsReadById(@Param("id") UUID id);
 
 	@Modifying(clearAutomatically = true)
-	@Query("UPDATE Notification n SET n.isDeleted = true WHERE n.receiverId = :id AND n.isDeleted = false")
+	@Query("UPDATE Notification n SET n.isDeleted = true WHERE n.receiverId = :id AND n.isDeleted = false AND n.notiChannel = 'WEB'")
 	void deleteAllNotification(@Param("id") UUID id);
 }

--- a/notification/src/main/java/com/tweaty/notification/presentation/controller/NotificationController.java
+++ b/notification/src/main/java/com/tweaty/notification/presentation/controller/NotificationController.java
@@ -123,7 +123,7 @@ public class NotificationController {
 
 		notificationService.deleteNotification(notiId, id);
 
-		return SuccessResponse.successMessageOnly("알림 전체 삭제 성공");
+		return SuccessResponse.successMessageOnly("알림 삭제 성공");
 	}
 
 	//알림 전체 삭제

--- a/notification/src/main/resources/application-local.yml
+++ b/notification/src/main/resources/application-local.yml
@@ -23,6 +23,19 @@ spring:
     init:
       mode: always
 
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: notification-service-group
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      #
+#      auto-offset-reset: earliest
+#      enable-auto-commit: false
+#    listener:
+#      ack-mode: manual
+#      type: single
+
 eureka:
   client:
     service-url:

--- a/user/build.gradle
+++ b/user/build.gradle
@@ -30,6 +30,7 @@ ext {
 
 dependencies {
     implementation project(":common")
+    implementation 'org.springframework.kafka:spring-kafka'
     implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
     annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"

--- a/user/src/main/java/com/tweaty/user/application/dto/NotificationRequestDto.java
+++ b/user/src/main/java/com/tweaty/user/application/dto/NotificationRequestDto.java
@@ -9,19 +9,18 @@ import domain.TargetType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class NotificationRequestDto {
 
 	private UUID receiverId;
 	private TargetType targetType; //RESERVATION, WAITING, SIGNUP
-	// private UUID targetId;
 	private Set<NotiChannel> notiChannel; //WEB, EMAIL
 	private NotiType notiType; //CREATED,UPDATED, CANCELLED, REMINDER, SIGNUP
-	// private NotiStatus notiStatus; //PENDING, SENT, FAILED
-
 	private String reason;
 
 }

--- a/user/src/main/java/com/tweaty/user/infrastructure/configuration/KafkaProducerConfig.java
+++ b/user/src/main/java/com/tweaty/user/infrastructure/configuration/KafkaProducerConfig.java
@@ -1,0 +1,31 @@
+package com.tweaty.user.infrastructure.configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@Configuration
+public class KafkaProducerConfig {
+
+	@Bean
+	public ProducerFactory<String, Object> producerFactory() {
+		Map<String, Object> config = new HashMap<>();
+		config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+		config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+		config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+		return new DefaultKafkaProducerFactory<>(config);
+	}
+
+	@Bean
+	public KafkaTemplate<String, Object> kafkaTemplate() {
+		return new KafkaTemplate<>(producerFactory());
+	}
+}

--- a/user/src/main/resources/application-local.yml
+++ b/user/src/main/resources/application-local.yml
@@ -23,6 +23,12 @@ spring:
     init:
       mode: always
 
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+
 eureka:
   client:
     service-url:


### PR DESCRIPTION
## PR
> **PR 타입(하나 이상의 PR 타입을 선택해주세요)**
> 
- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ]  문서 추가/수정
- [ ]  리팩토링

> 반영 브랜치
> 
- Source: feat/ #55_user_noti_redis_kafka
- Target: develop

> **변경 사항**
> 

* Auth Service에 redis, kafka 추가
* User Service에 kafka 추가
* Notification Service에 kafka 추가 (회원 관련 알림)


> 리뷰 요청
> 

> **검증 여부**
> 
- [x]  Postman으로 API 테스트 완료
- [ ]  로컬에서 기능 정상 동작 확인
- [ ]  단위 테스트 작성 및 통과 확인

> 이슈 닫기
>
Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced token reissue and logout endpoints for improved authentication management.
  - Added JWT-based refresh token support with Redis-backed storage and token blacklisting.
  - Integrated Kafka for asynchronous notification processing across services.
  - Added Docker Compose setup for local development with Kafka, Redis, and related services.

- **Improvements**
  - Enhanced notification handling by consuming messages from Kafka.
  - Updated notification and user services to use Kafka for sending notifications.
  - Refined notification bulk operations to target only web channel notifications.

- **Bug Fixes**
  - Corrected notification deletion response message to accurately reflect single notification deletion.

- **Configuration**
  - Added and updated Redis and Kafka settings in application configuration files for all relevant modules.
  - Enabled reactive Redis support in the gateway.

- **Chores**
  - Added necessary dependencies for Kafka and Redis integration in build files.

- **Style**
  - Minor formatting and comment cleanups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->